### PR TITLE
Fix path resolution so the pipeline runs on Windows

### DIFF
--- a/pipeline/scripts/build_parts_template.mjs
+++ b/pipeline/scripts/build_parts_template.mjs
@@ -3,12 +3,13 @@
 //   node scripts/build_parts_template.mjs --only     … プラグイン型だけの slide-spec/parts_template.json も書く（個別QA用）
 import fs from "node:fs/promises";
 import path from "node:path";
-const root = new URL("..", import.meta.url).pathname;
+import { fileURLToPath, pathToFileURL } from "node:url";
+const root = fileURLToPath(new URL("..", import.meta.url));
 const dir = path.join(root, "scripts/archetypes");
 const files = (await fs.readdir(dir)).filter((f) => f.endsWith(".mjs") && !f.startsWith("_")).sort();
 const mods = [];
 for (const f of files) {
-  const m = await import(path.join(dir, f));
+  const m = await import(pathToFileURL(path.join(dir, f)).href);
   if (m.id && m.example) mods.push(m);
 }
 mods.sort((a, b) => (a.part || 99) - (b.part || 99));

--- a/pipeline/scripts/export_spec_to_editable_pptx.mjs
+++ b/pipeline/scripts/export_spec_to_editable_pptx.mjs
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { createRequire } from "node:module";
 
 const defaultNodeModules =
@@ -18,7 +19,7 @@ const pptxgen = load("pptxgenjs");
 const inputArg = process.argv[2] || "slide-spec/synthetic_b2b_growth.json";
 const outputArg = process.argv[3] || "generated/synthetic_b2b_growth_editable.pptx";
 
-const root = new URL("..", import.meta.url).pathname;
+const root = fileURLToPath(new URL("..", import.meta.url));
 const inputPath = path.resolve(root, inputArg);
 const outputPath = path.resolve(root, outputArg);
 const deck = JSON.parse(await fs.readFile(inputPath, "utf8"));
@@ -1590,7 +1591,7 @@ const ARCHETYPES = await (async () => {
   let files = [];
   try { files = (await fs.readdir(dir)).filter((f) => f.endsWith(".mjs") && !f.startsWith("_")).sort(); } catch { return map; }
   for (const f of files) {
-    const mod = await import(path.join(dir, f));
+    const mod = await import(pathToFileURL(path.join(dir, f)).href);
     if (mod.id && typeof mod.pptx === "function") map.set(mod.id, mod);
   }
   return map;

--- a/pipeline/scripts/html_to_pdf.mjs
+++ b/pipeline/scripts/html_to_pdf.mjs
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { createRequire } from "node:module";
 
 const moduleDir = process.env.PLAYWRIGHT_MODULE_DIR || process.env.NODE_PATH || "";
@@ -19,7 +20,7 @@ if (!input || !output) {
   process.exit(1);
 }
 
-const root = new URL("..", import.meta.url).pathname;
+const root = fileURLToPath(new URL("..", import.meta.url));
 const htmlPath = path.resolve(root, input);
 const pdfPath = path.resolve(root, output);
 

--- a/pipeline/scripts/qa_html_deck.mjs
+++ b/pipeline/scripts/qa_html_deck.mjs
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { createRequire } from "node:module";
 
 const defaultNodeModules =
@@ -18,7 +19,7 @@ const { chromium } = load("playwright");
 const input = process.argv[2] || "generated/synthetic_b2b_growth.html";
 const output = process.argv[3] || "generated/quality-qa.json";
 
-const root = new URL("..", import.meta.url).pathname;
+const root = fileURLToPath(new URL("..", import.meta.url));
 const htmlPath = path.resolve(root, input);
 const outputPath = path.resolve(root, output);
 

--- a/pipeline/scripts/render_html_screenshots.mjs
+++ b/pipeline/scripts/render_html_screenshots.mjs
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { createRequire } from "node:module";
 
 const defaultNodeModules =
@@ -18,7 +19,7 @@ const { chromium } = load("playwright");
 const input = process.argv[2] || "html-css/styleguide.html";
 const outputDir = process.argv[3] || "examples/screenshots";
 
-const root = new URL("..", import.meta.url).pathname;
+const root = fileURLToPath(new URL("..", import.meta.url));
 const htmlPath = path.resolve(root, input);
 const screenshotsDir = path.resolve(root, outputDir);
 

--- a/pipeline/scripts/render_spec_to_html.mjs
+++ b/pipeline/scripts/render_spec_to_html.mjs
@@ -1,10 +1,11 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 const input = process.argv[2] || "slide-spec/synthetic_b2b_growth.json";
 const output = process.argv[3] || "generated/synthetic_b2b_growth.html";
 
-const root = new URL("..", import.meta.url).pathname;
+const root = fileURLToPath(new URL("..", import.meta.url));
 const inputPath = path.resolve(root, input);
 const outputPath = path.resolve(root, output);
 const spec = JSON.parse(await fs.readFile(inputPath, "utf8"));
@@ -60,7 +61,7 @@ const ARCHETYPES = await (async () => {
   let files = [];
   try { files = (await fs.readdir(dir)).filter((f) => f.endsWith(".mjs") && !f.startsWith("_")).sort(); } catch { return map; }
   for (const f of files) {
-    const mod = await import(path.join(dir, f));
+    const mod = await import(pathToFileURL(path.join(dir, f)).href);
     if (mod.id) { map.set(mod.id, mod); templates.add(mod.id); }
   }
   return map;

--- a/pipeline/scripts/validate_spec.mjs
+++ b/pipeline/scripts/validate_spec.mjs
@@ -4,8 +4,9 @@
 // Usage: node scripts/validate_spec.mjs <spec.json>   (exit 1 on any error)
 import fs from "node:fs/promises";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
-const root = new URL("..", import.meta.url).pathname;
+const root = fileURLToPath(new URL("..", import.meta.url));
 const specArg = process.argv[2];
 if (!specArg) {
   console.error("usage: node scripts/validate_spec.mjs <spec.json>");


### PR DESCRIPTION
## 概要

Windows 上でパイプラインの全スクリプトが、実処理に入る前にエラー終了します。原因はパス形式の扱い2点で、**ロジックの変更はありません**。どちらの修正も POSIX 側では挙動が変わりません（no-op）。

## 不具合1: `C:\C:\...` という二重ドライブのパスになる

`new URL("..", import.meta.url).pathname` は Windows では `/C:/Users/...` を返します。これを `path.resolve()` に渡すと、先頭の `/` があるためドライブ名が付け足され、`C:\C:\Users\...` という存在しないパスになります。

```
Error: ENOENT: no such file or directory, open
  'C:\C:\Users\...\pipeline\slide-spec\schema.json'
```

→ `fileURLToPath()` を使うよう変更。

## 不具合2: 動的 import に Windows パスを渡している

archetype プラグインの読み込みで `await import(path.join(dir, f))` としていますが、ESM の動的 import は URL を要求するため `C:\...` は受け付けられません。

```
Error: ERR_UNSUPPORTED_ESM_URL_SCHEME
```

→ `pathToFileURL(...).href` でラップ。

## 変更ファイル（7件）

`validate_spec` / `render_spec_to_html` / `qa_html_deck` / `export_spec_to_editable_pptx` / `html_to_pdf` / `render_html_screenshots` / `build_parts_template`

## 動作確認

Windows 11 / Node v24.14.0 にて、修正後に以下を確認しました。

| 項目 | 結果 |
| --- | --- |
| `validate` → `render` → `qa` → `export`（`slide-spec/example_deck.json`） | 全て成功・編集可能PPTX 3枚を生成 |
| 生成PPTXを `scripts/check_deck.py` で検査 | 0 FAIL |
| `templates/freeform_parts_16x9.html` を `check_deck.py` / `check_layout.mjs` で検査 | 0 FAIL・layout OK（回帰なし） |

素晴らしいスキルをありがとうございます。Windows 環境で使わせていただく中で見つけたものです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
